### PR TITLE
Makes logo in readme change depending on GH theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-![Retro Logo](https://cdn.discordapp.com/attachments/877153311151775805/1089945686436491324/retro-02.png)
+![Retro Logo](https://user-images.githubusercontent.com/60364512/228030301-f2139d22-48da-412b-9862-8f72e471e89c.png#gh-dark-mode-only) 
+
+![Retro Logo](https://user-images.githubusercontent.com/60364512/228030177-6b7a51f2-fe24-4ce4-8235-8d35f2526250.png#gh-light-mode-only)
 An OTR generation tool.
 
 ## Getting Started


### PR DESCRIPTION
Realised there was a much better way of doing this than the stroke I had added before

With light mode:
<img width="909" alt="image" src="https://user-images.githubusercontent.com/60364512/228030878-972da06f-23f7-4d40-a6f7-b439588d9c5b.png">

With dark mode:
<img width="906" alt="image" src="https://user-images.githubusercontent.com/60364512/228030981-fb55a27f-ac18-44bb-935a-5351a427ca2d.png">
